### PR TITLE
ci: add Gravity to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build Project
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - name: Node.js
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+        with:
+          registry-url: "https://registry.npmjs.org"
+      - name: install dependencies
+        run: pnpm i
+      - name: Build project
+        run: pnpm -r build
+      - name: Run Gravity
+        run: pnpx @gravityci/cli "websites/mswjs.io/dist/**/*"
+        env:
+          GRAVITY_TOKEN: ${{ secrets.GRAVITY_TOKEN }}


### PR DESCRIPTION
Hi! I'm @oscard0m, and I work at [Mainmatter](https://mainmatter.com).

We really appreciate the great work you're doing at _`mswjs/mswjs.io`_! We thought [Gravity](https://gravity.ci) could be useful to the project.

## What is Gravity?

Gravity is a free tool that helps maintainers stay on top of asset size increases as part of their CI pipeline. Gravity catches potentially unintended or disproportionate growth of _assets/bundle_ sizes that result out of code changes in a PR before they hit
  production, e.g. added dependencies that grow the _bundle_ size disproportionally. Without Gravity, it's hard for maintainers to even be aware of these changes, and _bundle/assets_ sizes often just keep growing unnoticed.

Here's a quick video showing Gravity in action:

https://youtu.be/2vD_geF_Ask

You can read a more detailed explanation in our
[blog post](https://gravity.ci/blog/2025/03/19/gravity/).

We also prepared an example PR with Gravity set up on a fork of _`mswjs/mswjs.io`_: https://github.com/mainmatter/mswjs.io/pull/1

## Last steps

This PR introduces Gravity to the project, but it is expected the maintainers
take some extra actions to connect all the dots:

1. Install [Gravity GitHub App](https://github.com/apps/gravity-ci) to your organization.
2. Once installed, create a new Gravity project in [https://gravity.ci](https://gravity.ci).
3. [Set up the Gravity token for your repo](https://github.com/<org>/<repo>/settings/secrets/actions) and add the Gravity job to your GitHub Actions workflow.